### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "issues": "https://github.com/swoole/etcd-client/issues"
   },
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1",
     "google/protobuf": "^3"
   },
   "autoload": {


### PR DESCRIPTION
调整 composer.json 的依赖对 PHP 的依赖，因为代码中存在大量 PHP 7.0 无法支持的语法，如 :void 返回类型， [] 替代 list() 等